### PR TITLE
Include WordPress file for `is_plugin_active` on frontend

### DIFF
--- a/includes/amazing-system.php
+++ b/includes/amazing-system.php
@@ -246,6 +246,17 @@ class MagicAmazingSystemPlugin {
 
 		}
 
+		/**
+		 * WordPress function `is_plugin_active` only in "admin" area
+		 *
+		 * To do this test on the front end (as we are in this short code)
+		 * we have to make sure the file containing the function is loaded.
+		 *
+		 * GitHub: Issue #4
+		 */
+		if ( !function_exists( 'is_plugin_active' ) ) {
+			include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+		}
 		if ( is_plugin_active( 'kswp_pop_wizard/kswp_pop_wizard.php' ) ) {
 			global $kswp_pop_wizard_var;
 			$as_form_html_value = $kswp_pop_wizard_var->kswp_pop_wizard_tooltip_html_js( $as_form_html_value );


### PR DESCRIPTION
WordPress itself only loads the file in the admin area

[Fixes #4]
