### PR TITLE
Switch shortcodes should match uppercase variables

### DIFF
--- a/includes/shortcode-switch.php
+++ b/includes/shortcode-switch.php
@@ -1,13 +1,13 @@
 <?php
 
 function as_switch_shortcode_cb ( $atts, $content = null ) {
-	
+
 	extract( shortcode_atts( array(
 		'default' => '',
 		'field' => ''
 		), $atts ) );
 	// Now $default and $field are available.
-	
+
 	/**
 	 * Exit early if "field" isn't defined.
 	 */
@@ -23,7 +23,7 @@ function as_switch_shortcode_cb ( $atts, $content = null ) {
 	$return  = $default;
 
 	$request = MagicAmazingSystemPlugin::$request;
-	
+
 	foreach ($atts as $key => $value) {
 
 		if ( 'default' == $key || 'field' == $key ) {
@@ -37,7 +37,7 @@ function as_switch_shortcode_cb ( $atts, $content = null ) {
 
 	foreach ($atts as $key => $value) {
 
-		if ( isset( $request[$field] ) && $request[$field] == $key ) {
+		if ( isset( $request[$field] ) && strtolower( $request[$field] ) === $key ) {
 			$return = $value;
 			return $return;
 		}


### PR DESCRIPTION
When using `[switch field="package" Gold="something gold specific" ... ]` (Note the capital **G** in _Gold_) it won't match upercase letters in the URI, but will match lowercase.

WordPress passes arguments through `shortcode_parse_atts($text)` which does a `strtolower($m[1])` on the attributes. I doubt its possible to make it case sensitive matching, but the code should be modified to run the URI through `strtolower` to at least allow case insensitive matching.

See the WordPress file [here](https://github.com/WordPress/WordPress/blob/master/wp-includes/shortcodes.php#L292)
