### PR TITLE
Nest additional shortcodes in `[switch]`

### DIFF
--- a/includes/amazing-system.php
+++ b/includes/amazing-system.php
@@ -4,6 +4,7 @@
 **/
 
 require_once 'shortcode-switch.php';
+require_once 'shortcode-block.php';
 require_once 'shortcode-get-current-version.php';
 
 if ( is_admin() ) {
@@ -343,5 +344,7 @@ EOF;
 
 add_filter('the_content', 'MagicAmazingSystemPlugin::stop_html_filter', 9);
 add_filter('the_content', 'MagicAmazingSystemPlugin::add_javascript_to_footer', 9);
+
+add_action( 'init', array( 'Amazing_System_Shortcode_Block', 'get_instance' ) );
 
 require_once( 'meta-box/example-functions.php' );

--- a/includes/shortcode-block.php
+++ b/includes/shortcode-block.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Amazing System Block Shortcode
+ *
+ * @package   Amazing_System
+ * @author    Scott Lesovic <scott@scottlesovic.com>
+ * @license   GPL-2.0+
+ * @link      http://scottlesovic.com
+ * @copyright 2013 Scott Lesovic
+ */
+
+class Amazing_System_Shortcode_Block {
+
+	protected $shortcode_tag = 'block';
+
+	protected static $instance = null;
+
+	protected $pairs = array(
+		'field' => '',
+		'value' => '',
+		'operator' => 'eq'   // Not used
+	);
+
+	/**
+	 * Initialize the plugin by setting localization and loading public scripts
+	 * and styles.
+	 */
+	private function __construct() {
+		add_shortcode ( $this->shortcode_tag, array( $this, 'fire' ) );
+	}
+
+
+	/**
+	 * Return an instance of this class.
+	 *
+	 * @return    object    A single instance of this class.
+	 */
+	public static function get_instance() {
+
+		// If the single instance hasn't been set, set it now.
+		if ( null == self::$instance ) {
+			self::$instance = new self;
+		}
+
+		return self::$instance;
+	}
+
+	public function fire( $atts, $content = null, $tag = "block" ) {
+
+		global $post;
+
+		$atts = $this->validate_attributes( $atts );
+
+		if ( is_wp_error( $atts ) && current_user_can( 'edit_post', $post->ID ) ) {
+			return '<code>' . $atts->get_error_message() . '</code>';
+		} elseif ( is_wp_error( $atts ) ) {
+			return;
+		}
+
+		if ( $this->should_be_shown( $atts['field'], $atts['value'] ) ) {
+			return do_shortcode( $content );
+		}
+
+		return;
+	}
+
+	private function validate_attributes( $atts ) {
+
+		$clean = shortcode_atts( $this->pairs, $atts, $this->shortcode_tag);
+
+		if ( '' === $clean['field'] ) {
+			return new WP_Error( 'amazing_system_shortcode_block_field_empty',
+				'Amazing System Plugin: "field" is required for the [block] shortcode.' );
+		}
+
+		if ( '' === $clean['value'] ) {
+			return new WP_Error( 'amazing_system_shortcode_block_field_empty',
+				'Amazing System Plugin: "value" is required for the [block] shortcode.' );
+		}
+
+		return $clean;
+	}
+
+	private function should_be_shown( $field, $value ) {
+
+		$request = MagicAmazingSystemPlugin::$request;
+
+		if ( !isset( $request[ $field ] ) ) {
+			return false;
+		}
+
+		$request = $request[ $field ];
+
+		if ( $value !== $request ) {
+			return false;
+		}
+
+		return true;
+	}
+
+
+}


### PR DESCRIPTION
After having a conversation with [Christopher Cool](http://www.christophercool.com), he is doing some really "cool" stuff with the `[switch]` shortcode.

The next level is using other shortcodes inside of a switch. This goes against the native WordPress shortcode functionality, so this may lend into starting a new shortcode displaying or hiding a content block based on `$_REQUEST` variables.

My initial thoughts are calling it **block**. The possible use is:

```
[block field="field1" value="show"]
    Hello there [as what="firstname"]! How are you today?
[/block]
```

A limitation I see initially is nesting blocks

```
[block field="field1" value="show"]
    [block field="field2" value="on"]
        Field 1 is showing and Field 2 is on.
    [/block]
    [block field="field2" value="off"]
        Field 1 is showing and Field 2 is off.
    [/block]
[/block]
```

This is probably a stand-alone issue, but still something to consider. Is the idea useful to have "advanced" control? `if field1=show AND field2=on` 

Also, is _block_ a good name? Any other ideas?
