### PR TITLE
Default merge codes not displaying with empty merge field

### DIFF
--- a/includes/amazing-system.php
+++ b/includes/amazing-system.php
@@ -51,43 +51,28 @@ class MagicAmazingSystemPlugin {
 		/**
 		* Returns the content of a $_GET or $_POST or $_SESSION variable, referenced via shortcode, e.g. put the
 		* following in the content of a post or page:
-		*     [as what="Name" default="default value" force="get/post"]
+		*     [as what="Name" default="default value"]
 		*/
 		public static function display_get_post_vars( $atts ) {
 			$firstname = '';
 			$lastname = '';
 			extract( shortcode_atts( array(
-											'what' => 'Name',
-											'default' => '',
-											), $atts ) ) ;
-
-			/*if ( !isset( $_REQUEST['Name'] ) && isset( $_SESSION['Name'] ) ) {
-				$_REQUEST['Name'] = $_SESSION['Name'];
-				}*/
+				'what' => 'Name',
+				'default' => '',
+				), $atts ) ) ;
 
 			$request = array();
 			$request = self::$request;
 
-			if ( $what == 'firstname' ) {
-					if ( isset( $request['Name'] )) {
-						list($firstname, $lastname) = explode(' ', $request['Name'], 2);
-						return trim($firstname);
-					}
-					/*if ( isset( $_GET['Name'] )) {
-						list($firstname, $lastname) = explode(' ', $_GET['Name'], 2);
-						return trim($firstname);
-					}*/
-			} else if ( $what === 'lastname' ) {
-				list($firstname, $lastname) = explode(' ', $request['Name'], 2);
-				return trim($lastname);
-			}
-			if ( isset( $request[$what] )) {
+			if ( $what == 'firstname' && isset( $request['Name'] ) && !empty( $request['Name'] ) ) {
+				list( $firstname, $lastname ) = ( preg_match( '/ ./', $request['Name']) ) ? explode(' ', $request['Name'], 2) : array( $request['Name'], $default );
+				return trim( $firstname );
+			} else if ( $what === 'lastname' && isset( $request['Name'] ) && !empty( $request['Name'] ) ) {
+				list( $firstname, $lastname ) = ( preg_match( '/ ./', $request['Name']) ) ? explode(' ', $request['Name'], 2) : array( $request['Name'], $default );
+				return trim( $lastname );
+			} else if ( isset( $request[$what] ) && !empty( $request[$what] ) ) {
 				$value = $request[$what];
-			} /*else if (isset( $_GET[$what])) {
-				$value = $_GET[$what];
-			} else if (isset( $_SESSION[$what])) {
-				$value = $_SESSION[$what];
-			} */else {
+			} else {
 				$value = $default;
 			}
 


### PR DESCRIPTION
The issue is in the hyperlink if I have: `...?Name=David&field8=`
(notice how field8 equals nothing)

the default does not display.
`[as what="field8" default="$400"]`

If I remove field8 completely from the hyperlink string, it then works and displays the default.

I want to merge in price but have a default set if I don't input the price I want to quote.

I hope this makes sense. Wondering if a field is in the hyperlink string but equals nothing, if that can then kick in the default in the AS merge code.

David 
