### PR TITLE
Add missing `break` control structure

### DIFF
--- a/includes/shortcode-block.php
+++ b/includes/shortcode-block.php
@@ -89,6 +89,7 @@ class AmSys_Shortcode_Block {
 				break;
 			case 'one of':
 				$display = $this->is_one_of( $value, $data );
+				break;
 			case 'contains':
 				$display = ( strpos( $data, $value ) ) ? true : false;
 				break;


### PR DESCRIPTION
The conditions in the `switch/case` statement were falling through unintentionally, producing unexpected results.

[Fixes: #23]
