### PR TITLE
Possible fix for #32

### DIFF
--- a/includes/amazing-system.php
+++ b/includes/amazing-system.php
@@ -118,7 +118,49 @@ class MagicAmazingSystemPlugin {
 				return trim( self::$request[ $field ] );
 			}
 
+			if ( self::is_a_default_1shop_field( $field ) ) {
+				return self::shortcode_merge_handler( array(
+						'what' => strtolower( $field ),
+						'default' => $default_value
+					) );
+			}
+
 			return $default_value;
+		}
+
+		/**
+		 * Request field is a default 1ShoppingCart field
+		 *
+		 * 1SC in an update made all their standard fields lower case. We need
+		 * to check if we are working with one of these fields and standardize
+		 * the casing of the variable.
+		 *
+		 * @param  string  $field The `$_REQUEST` field
+		 * @return boolean
+		 */
+		private static function is_a_default_1shop_field( $field ) {
+
+			if ( $field === strtolower( $field ) ) {
+				return false;
+			}
+
+			$fields = array(
+				'email1',
+				'company',
+				'workphone',
+				'homephone',
+				'fax',
+				'address1',
+				'address2',
+				'city',
+				'state',
+				'zip',
+				'country'
+			);
+
+			$field = strtolower( $field );
+
+			return in_array( $field, $fields, true );
 		}
 
 		/**

--- a/includes/amazing-system.php
+++ b/includes/amazing-system.php
@@ -138,7 +138,7 @@ class MagicAmazingSystemPlugin {
 		 * @param  string  $field The `$_REQUEST` field
 		 * @return boolean
 		 */
-		private static function is_a_default_1shop_field( $field ) {
+		public static function is_a_default_1shop_field( $field ) {
 
 			if ( $field === strtolower( $field ) ) {
 				return false;

--- a/includes/shortcode-block.php
+++ b/includes/shortcode-block.php
@@ -117,12 +117,16 @@ class AmSys_Shortcode_Block {
 	private function get_field( $key, $default = null) {
 		$data = $this->data;
 
-		if ( ! isset( $data[ $key ] ) || empty( $data[ $key ] ) ) {
+		if ( ! isset( $data[ $key ] ) && ! MagicAmazingSystemPlugin::is_a_default_1shop_field( $key ) ) {
 			return $default;
 		}
 
 		if ( isset( $data[ $key ] ) ) {
 			return $data[ $key ];
+		}
+
+		if ( MagicAmazingSystemPlugin::is_a_default_1shop_field( $key ) ) {
+			return $this->get_field( strtolower( $key ), $default );
 		}
 
 		return false;

--- a/includes/shortcode-switch.php
+++ b/includes/shortcode-switch.php
@@ -46,6 +46,13 @@ function as_switch_shortcode_cb ( $atts, $content = null ) {
 			$return = $value;
 			return $return;
 		}
+
+		if ( MagicAmazingSystemPlugin::is_a_default_1shop_field( $field ) ) {
+			$atts[ 'field' ] = strtolower( $field );
+			$atts[ 'default' ] = $default;
+			$return = as_switch_shortcode_cb( $atts );
+			continue;
+		}
 	}
 
 	return $return;


### PR DESCRIPTION
For `[as what ... ]`, `[switch field ... ]`, and `[block field ... ]`, we are comparing against 11 of 1ShoppingCart's fields for capitalization.

The way this works is if something matches without the check, we use that. Otherwise, if the field we are trying to use is available in it's lowercase form, we will use that.

What won't work is to use the lower case version of the name within the shortcode.

Example: `[as what="company"]` will not work with an old form using `Company`, but it will respond to the new form's `company`.

Only `[as what="Company"]` will respond to both the old form's `Company` *(preferred)* and the new form's `company`.

I think this is acceptable, since what we recommend, and generate, is the capitalized version of the field.